### PR TITLE
Prefer `glue_data()` when the data source is a list

### DIFF
--- a/R/table_ester.R
+++ b/R/table_ester.R
@@ -161,7 +161,7 @@ table_ester <- function(estimate,
   .envir <- list(estimate = .estimate, error = .error)
 
   as.character(
-    do.call(glue::glue, args = list(form, .envir = .envir))
+    do.call(glue::glue_data, args = list(form, .x = .envir))
   )
 
 }
@@ -267,7 +267,7 @@ table_estin <- function(estimate,
   .envir <- list(estimate = .estimate, lower = .lower, upper = .upper)
 
   as.character(
-    do.call(glue::glue, args = list(form, .envir = .envir))
+    do.call(glue::glue_data, args = list(form, .x = .envir))
   )
 
 }

--- a/R/table_value.R
+++ b/R/table_value.R
@@ -45,7 +45,7 @@ table_value <- function(x, rspec = NULL){
               expected  = list(class = 'rounding_specification'))
 
   # use the format(round()) combination dictated by .rspec
-  switch(glue::glue("{round_using}_{round_half}", .envir = .rspec),
+  switch(glue::glue_data(.rspec, "{round_using}_{round_half}"),
          "decimal_up"     = fr_decimal_up(x, .rspec),
          "decimal_even"   = fr_decimal_even(x, .rspec),
          "signif_up"      = fr_signif_up(x, .rspec),


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. I'm going to temporarily back off on the associated change in glue, just so I can release without any breakage of other packages.

But please do consider this a heads up that, in the future, `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I'd like to make that actually true.

OTOH `glue_data()` *does* officially accept something "list-ish" as `.x`. So I think it's a better choice for your usage.

Backstory in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764